### PR TITLE
Allow db.coll names greater than 70 chars

### DIFF
--- a/mongocacheview.js
+++ b/mongocacheview.js
@@ -57,7 +57,8 @@ while(true){
 		pageUseDiff = Math.floor((pagesUsed - collInfo.pagesUsed)/reportTime)
 
 		name =  collInfo.db + "." + collInfo.coll
-		name = name + Array(70 - name.length).join(" ")
+                lgth = name.length<=70?name.length:70
+                name = name + Array(70 - lgth).join(" ")
 
 		if(collSize > 0) {
 			pc = Math.floor((inCache / collSize) * 100)


### PR DESCRIPTION
Some people use _database.collection_ names greater than 70 characters long.